### PR TITLE
Ivan/parallel run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "modelator_py"
-version = "0.1.8"
+version = "0.1.9"
 description = "Lightweight utilities to assist model writing and model-based testing activities using the TLA+ ecosystem"
 authors = ["Daniel Tisdall <daniel@informal.systems>", "Ivan Gavran <ivan@informal.systems>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "modelator_py"
-version = "0.1.9"
+version = "0.2.0"
 description = "Lightweight utilities to assist model writing and model-based testing activities using the TLA+ ecosystem"
 authors = ["Daniel Tisdall <daniel@informal.systems>", "Ivan Gavran <ivan@informal.systems>"]
 readme = "README.md"


### PR DESCRIPTION
With this PR, `stringify_raw_cmd` for both Apalache and TLC takes `java_temp_dir` as an argument. It prepends it to the java command, making sure that `java.io.tmpdir` has different value for different runs of the solver. 
(It is a workaround for [this issue](https://github.com/tlaplus/tlaplus/issues/688)) 