### PR TITLE
Adding quotes around the jar path

### DIFF
--- a/modelator_py/apalache/raw.py
+++ b/modelator_py/apalache/raw.py
@@ -36,7 +36,7 @@ def stringify_raw_cmd(cmd: RawCmd, java_temp_dir: str = None):
     args = ApalacheArgs(**{k: stringify(v) for k, v in asdict(args).items()})
 
     cmd_str = f"""java{tmpdir_setup}\
- -jar {jar}\
+ -jar "{jar}"\
 {f" --config-file={args.config_file}" if args.config_file is not None else ""}\
 {f" --debug={args.debug}" if args.debug is not None else ""}\
 {f" --out-dir={args.out_dir}" if args.out_dir is not None else ""}\

--- a/modelator_py/tlc/raw.py
+++ b/modelator_py/tlc/raw.py
@@ -39,7 +39,7 @@ def stringify_raw_cmd(cmd: RawCmd, java_temp_dir: str = None) -> str:
     args = TlcArgs(**{k: stringify(v) for k, v in asdict(args).items()})
 
     cmd_str = f"""java{tmpdir_setup}\
- -cp {jar}\
+ -cp "{jar}"\
  tlc2.TLC\
 {f" -aril {args.aril}" if args.aril is not None else ""}\
 {f" -checkpoint {args.checkpoint}" if args.checkpoint is not None else ""}\

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "modelator_py"
-version = "0.2.0"
+version = "0.2.1"
 description = "Lightweight utilities to assist model writing and model-based testing activities using the TLA+ ecosystem"
 authors = ["Daniel Tisdall <daniel@informal.systems>", "Ivan Gavran <ivan@informal.systems>"]
 readme = "README.md"


### PR DESCRIPTION
When a command string (`cmd_str`) is generated, it does not add quotes around the path to the jar. This can be a problem for paths which contains folders with blank spaces in them.